### PR TITLE
Reword supported versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Install from ``pip`` with:
 
      pip install flake8-no-types
 
-Python 3.5-3.8 supported.
+Python 3.5 to 3.8 supported.
 
 When installed it will automatically be run as part of ``flake8``; you can
 check it is being picked up with:


### PR DESCRIPTION
As per https://github.com/adamchainz/django-cors-headers/pull/468 , using a dash has confused some users.